### PR TITLE
Allow doctrine/annotations 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require": {
 		"php": ">=7.4",
 		"ext-json": "*",
-		"doctrine/annotations": "^1.11",
+		"doctrine/annotations": "^1.11 | ^2.0",
 		"symfony/config": "^5.0",
 		"symfony/dependency-injection": "^5.0",
 		"symfony/http-kernel": "^5.0",


### PR DESCRIPTION
Allow installing with doctrine/annotations 2.0

Unit tests still work. 

Seeing one deprecated message i'll add another PR for:
PHP Deprecated:  Return type of Iwink\GitLabWebhookBundle\Event\WebhookEvent::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /src/Event/WebhookEvent.php on line 91

Refs #7 

