### PR TITLE
Unknown parameters are skipped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - 8.1 code compatibility.
+- Unknown parameters caused an exception to be thrown on replacement.
 
 ### Changed
 - Updated `doctrine/annotations` dependency to allow `^2.0`.

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
 		"php": ">=7.4",
 		"ext-json": "*",
 		"doctrine/annotations": "^1.11|^2.0",
-		"symfony/config": "^5.0",
-		"symfony/dependency-injection": "^5.0",
-		"symfony/http-kernel": "^5.0",
-		"symfony/yaml": "^5.0"
+		"symfony/config": "^5.0|^6.0",
+		"symfony/dependency-injection": "^5.0|^6.0",
+		"symfony/http-kernel": "^5.0|^6.0",
+		"symfony/yaml": "^5.0|^6.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.4",

--- a/src/Annotation/Reflection/ParameterAwareTrait.php
+++ b/src/Annotation/Reflection/ParameterAwareTrait.php
@@ -23,6 +23,7 @@ trait ParameterAwareTrait {
 	 *
 	 * @since 1.1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function getDocComment() {
 		$comment = parent::getDocComment();
 		if (false === $comment || null === $this->parameterBag) {
@@ -34,8 +35,11 @@ trait ParameterAwareTrait {
 			$lines[] = preg_replace_callback(
 				'/%([^%]+)%/',
 				function (array $matches): string {
-					$parameter = $this->parameterBag->resolveValue($matches[0]);
+					if (!$this->parameterBag->has($matches[1])) {
+						return $matches[1];
+					}
 
+					$parameter = $this->parameterBag->resolveValue($matches[0]);
 					return is_array($parameter) ? sprintf('{"%s"}', implode('","', $parameter)) : $parameter;
 				},
 				$line

--- a/src/Annotation/Reflection/ParameterAwareTrait.php
+++ b/src/Annotation/Reflection/ParameterAwareTrait.php
@@ -36,7 +36,7 @@ trait ParameterAwareTrait {
 				'/%([^%]+)%/',
 				function (array $matches): string {
 					if (!$this->parameterBag->has($matches[1])) {
-						return $matches[1];
+						return $matches[0];
 					}
 
 					$parameter = $this->parameterBag->resolveValue($matches[0]);

--- a/tests/Annotation/ParameterAwareReaderTest.php
+++ b/tests/Annotation/ParameterAwareReaderTest.php
@@ -13,6 +13,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 final class ParameterAwareReaderTest extends TestCase
 {
+	/**
+	 * Test case for {@see ParameterAwareReader::getMethodAnnotations()} with a PHPDoc that has a random,
+	 * non-existent parameter reference.
+	 * @since $ver$
+	 */
 	public function testReader(): void
 	{
 		$parameter_bag = new ParameterBag([

--- a/tests/Annotation/ParameterAwareReaderTest.php
+++ b/tests/Annotation/ParameterAwareReaderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Iwink\GitLabWebhookBundle\Tests\Annotation;
+
+use Iwink\GitLabWebhookBundle\Annotation\ParameterAwareReader;
+use Iwink\GitLabWebhookBundle\Annotation\Webhook;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * Unit tests for {@see ParameterAwareReader}.
+ * @since $ver$
+ */
+final class ParameterAwareReaderTest extends TestCase
+{
+	public function testReader(): void
+	{
+		$parameter_bag = new ParameterBag([
+			'secret_token' => 'SuperSecret123',
+		]);
+		$reader = new ParameterAwareReader($parameter_bag);
+
+		$annotations = $reader->getMethodAnnotations(
+			new \ReflectionMethod(TestClassForReflection::class, 'testMethod')
+		);
+		self::assertEquals([new Webhook(['event' => 'pipeline', 'tokens' => ['SuperSecret123']])], $annotations);
+	}
+}
+
+final class TestClassForReflection
+{
+	/**
+	 * some comment with an {"%invalid_token%"}
+	 * @Webhook("pipeline", tokens={"%secret_token%"})
+	 */
+	public function testMethod(): void
+	{
+	}
+}


### PR DESCRIPTION
This is a pragmatic fix for #10 for now. The next minor / major release should move this behavior to only be used on the `Webhook` annotation.